### PR TITLE
Update versions for github action dependencies

### DIFF
--- a/.github/workflows/DeployStaticPortal.yml
+++ b/.github/workflows/DeployStaticPortal.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:  
   push:
     branches: 
-      - master 
+      - master
+      - main 
       
 jobs:
   generate-portal:
@@ -12,7 +13,7 @@ jobs:
 
     steps:
        
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       name : checkout-repo
       id: checkout-repo  
       
@@ -43,7 +44,7 @@ jobs:
       
     - name: Deploy to Netlify
       if: ${{steps.generate-portal.outputs.HTTP_CODE == '200'}}
-      uses: nwtgck/actions-netlify@v2.0
+      uses: nwtgck/actions-netlify@v3.0
       with:
         publish-dir: './static-portal'
         production-branch: master
@@ -60,7 +61,7 @@ jobs:
       # Upload Portal Artifact
     - name: Upload Artifact
       if: ${{steps.generate-portal.outputs.HTTP_CODE == '200' }}
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v4.0
       with:
         name: static-portal
         path: static-portal
@@ -73,7 +74,7 @@ jobs:
     # Upload error.zip if error code is 422 with a zip file
     - name: Upload error.zip
       if: ${{steps.generate-portal.outputs.HTTP_CODE == '422' && steps.generate-portal.outputs.CONTENT_TYPE == 'application/zip'}}
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v4.0
       with:
         name: error
         path: error

--- a/.github/workflows/DeployStaticPortal.yml
+++ b/.github/workflows/DeployStaticPortal.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: 
       - master
-      - main 
       
 jobs:
   generate-portal:


### PR DESCRIPTION
Some of the action versions have now been [deprecated](https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact), this PR is to simply update the workflow.yml to update these dependencies to their latest versions.

